### PR TITLE
Add bootloader and kernel shims

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,10 +12,11 @@ c_sources = [
     'src/kernel/kernel_support.c',
     'src/kernel/environment.c',
     'src/kernel/abort.c',
+    'src/kernel/boot.c',
+    'src/kernel/kernel_main.c',
     'src/kernel/sbrk.c',
     'src/nongnu/unistd.c',
-    'src/drivers/uart.c',
-    'src/programs/dma.c'
+    'src/drivers/uart.c'
 ]
 
 # List of ASM sources to compile.  Relative to project root.
@@ -27,6 +28,9 @@ asm_sources = [
 ## project setup
 # CPU to use (default: on FRDM-K64F)
 add_project_arguments('-DCPU_MK64FN1M0VLL12', language: 'c')
+
+# Set the entry point to be bootloader_entry
+add_project_arguments('-D__START=bootloader_entry', language: 'c')
 
 # use default clock?
 # This is Kinetis-setup specific, and configures the Freescale MCG on boot.

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -9,6 +9,12 @@
  */
 extern void kernel_main(const char *cmdline);
 
+/**
+ * Provided by NXP startup code. Ensures SystemCoreClock (global var) is
+ * correct.
+ */
+extern void SystemCoreClockUpdate(void);
+
 static const char kernel_commandline[] = "";
 
 
@@ -16,6 +22,7 @@ __attribute__((noreturn))
 void bootloader_entry() {
     // if there are pre-kernel drivers that need initialization, those would
     // go here.
+    SystemCoreClockUpdate();
 
     // branch to the entry point
     kernel_main(kernel_commandline);

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -1,0 +1,25 @@
+#include <stddef.h>
+/**
+ * This file is a shim for a real bootloader.  It acts as a way to call the
+ * kernel with a command line, if any, from an already-running CPU and memory.
+ */
+
+/**
+ * This function is the entry for the OS kernel or other baremetal program.
+ */
+extern void kernel_main(const char *cmdline);
+
+static const char kernel_commandline[] = "";
+
+
+__attribute__((noreturn))
+void bootloader_entry() {
+    // if there are pre-kernel drivers that need initialization, those would
+    // go here.
+
+    // branch to the entry point
+    kernel_main(kernel_commandline);
+    // this is for safety, in case the kernel main exits or spuriously branches
+    // to the link register.
+    for(;;);
+}

--- a/src/kernel/kernel_main.c
+++ b/src/kernel/kernel_main.c
@@ -1,0 +1,18 @@
+/**
+ * This file is a shim to allow separation of kernel and application code if it
+ * is needed in a future application.
+ */
+
+extern int main(void);
+
+__attribute__((noreturn))
+void kernel_main(const char *cmdline) {
+    // parse the command line here
+
+    // device initialization here
+
+    // branch to main. Catch the program counter if the application main
+    // exits, faults, or spuriously returns.
+    main();
+    for(;;);
+}

--- a/src/kernel/kernel_main.c
+++ b/src/kernel/kernel_main.c
@@ -3,11 +3,16 @@
  * is needed in a future application.
  */
 
+#include <kernel/kernel_ftab.h> /* ftab_init, temporary */
+
 extern int main(void);
 
 __attribute__((noreturn))
 void kernel_main(const char *cmdline) {
     // parse the command line here
+
+    // kernel structure initialization here
+    ftab_init();
 
     // device initialization here
 

--- a/src/kernel/kernel_main.c
+++ b/src/kernel/kernel_main.c
@@ -5,7 +5,8 @@
 
 #include <kernel/kernel_ftab.h> /* ftab_init, temporary */
 
-extern int main(void);
+__attribute__((weak))
+int main() { return 0; }
 
 __attribute__((noreturn))
 void kernel_main(const char *cmdline) {


### PR DESCRIPTION
This is just in case there is a need for bootloader or kernel initialization in the future.  Right now, the changes amount to a skeleton that simply calls the application main. If no main is provided, the kernel simply waits indefinitely.