### PR TITLE
Fixed allocation issue with Proces Control Blocks.

### DIFF
--- a/include/kernel/process.h
+++ b/include/kernel/process.h
@@ -29,7 +29,7 @@ typedef struct {
  */
 typedef struct {
     pcb_t **proc_list;
-    pcb_t *curr_proc;
+    pcb_t **curr_proc;
     int next_pid;
     int num_processes;
 } proc_table_t;

--- a/src/kernel/arm/cm4/schedule_entry.S
+++ b/src/kernel/arm/cm4/schedule_entry.S
@@ -44,6 +44,7 @@ PendSV_Handler:
 
     // save the psp to the pcb
     ldr r0, [r12, #4] // r0 has curr_proc (pointer)
+    ldr r0, [r0, #0]
     str r1, [r0, #0] // save psp (points to END of stack AFTER context push)
 
     // save the exc_return value to the pcb

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -8,7 +8,7 @@
 int scheduler_init(proc_table_t *process_table, pcb_t **proc_list) {
     int status = 0;
     process_table->proc_list = proc_list;
-    process_table->curr_proc = *process_table->proc_list;
+    process_table->curr_proc = process_table->proc_list;
     process_table->next_pid = 1;
     process_table->num_processes = 0;
     return status;
@@ -32,14 +32,14 @@ done:
 
 // This is just a round-robin scheduler.  Not very efficient, but it will do.
 pcb_t *scheduler_main(proc_table_t *process_table) {
-    if(process_table->curr_proc - process_table->proc_list[0] ==
+    if(process_table->curr_proc - process_table->proc_list ==
             (process_table->num_processes - 1)) {
-        process_table->curr_proc = process_table->proc_list[0];
+        process_table->curr_proc = process_table->proc_list;
     }
     else {
         process_table->curr_proc++;
     }
     // configure MCM and MPU for memory protection
-    MCM->PID = process_table->curr_proc->pid;
-    return process_table->curr_proc;
+    MCM->PID = (*process_table->curr_proc)->pid;
+    return *(process_table->curr_proc);
 }


### PR DESCRIPTION
Usage of pointer-array for pcbs in the kernel was wrong.  The bug has
been fixed so that the actual pcb table is now correct, and the ARM CM4
port has been updated to reflect that change.