### PR TITLE
Fixed SH int. priorities.

### DIFF
--- a/src/kernel/kernel_main.c
+++ b/src/kernel/kernel_main.c
@@ -29,10 +29,12 @@ void kernel_main(const char *cmdline) {
     // device initialization here
 
     /** PROCESS SCHEDULER INITIALIZATION **/
-    // SVCall has priority 14
-    SCB->SHP[2] |= (14 << 24);
-    // PendSV has priority 15
-    SCB->SHP[3] |= (15 << 16);
+    // SysTick has priority 15
+    SCB->SHP[3] |= (15 << 24);
+    // PendSV has priority 14
+    SCB->SHP[3] |= (14 << 16);
+    // SVCall has priority 13
+    SCB->SHP[2] |= (13 << 24);
     scheduler_init(&process_table, &process_list);
 
     /** USER PROCESS START **/


### PR DESCRIPTION
 + System Handler Priority registers have been appropriately assigned
   for SysTick (15), PendSV (14), and SVCall (13).

Note:
These changes are not necessarily portable to another system. They have
been set to the lowest priorities available on NXP's implementation of
ARMv7-M.  We have no facility for doing this generically at the current
moment.