### PR TITLE
Added XPC Relay on UART0 as a process.

### DIFF
--- a/include/programs/xpc_relay_event_loop.h
+++ b/include/programs/xpc_relay_event_loop.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <tinyxpc/tinyxpc.h>
+#include <tinyxpc/xpc_relay.h>
+#include <kernel/process.h>
+
+/**
+ * IPC interface-related items
+ */
+
+typedef struct {
+    int fd;
+    bool notify_on_read, notify_on_write;
+    char read_buf[255];
+} uart_relay_ctx_t;
+
+extern volatile xpc_relay_state_t uart0_relay;
+extern xpc_relay_state_t *comms_relay;
+
+void xpc_yield_until_ready();
+
+/**
+ * Process-related items
+ */
+#define XPC_RELAY_STACK_SIZE 100
+
+extern pcb_t xpc_relay_event_loop_app;
+extern uint32_t xpc_relay_event_loop_stack[XPC_RELAY_STACK_SIZE];
+
+int xpc_relay_event_loop_main(void);

--- a/src/programs/main.c
+++ b/src/programs/main.c
@@ -8,8 +8,10 @@
 #include <kernel/private/static_memory.h>
 #include <kernel/schedule.h>
 #include <drivers/arm/cm4/systick.h>
-#include <programs/sensor_read.h>
 #include <drivers/devices/status_leds.h>
+#include <programs/sensor_read.h>
+#include <programs/xpc_relay_event_loop.h>
+#include <programs/xpc_spammer.h>
 
 /**
  * Entry point for the process switcher.
@@ -19,6 +21,12 @@ int init_main(void) {
     process_init(&sensor_read_app, &sensor_read_main, sensor_read_stack,
                  SENSOR_READ_STACK_SIZE, true, false);
     schedule_process(&process_table, &sensor_read_app);
+#endif
+
+#ifdef TASK_EN_XPC_RELAY
+    process_init(&xpc_relay_event_loop_app, &xpc_relay_event_loop_main,
+            xpc_relay_event_loop_stack, XPC_RELAY_STACK_SIZE, false, false);
+    schedule_process(&process_table, &xpc_relay_event_loop_app);
 #endif
     return 0;
 }

--- a/src/programs/meson.build
+++ b/src/programs/meson.build
@@ -1,6 +1,7 @@
 c_sources = get_variable('c_sources', [])
 devices_required = get_variable('devices_required', [])
 peripherals_required = get_variable('peripherals_required', [])
+    dependencies = get_variable('dependencies', [])
 
 # init main
 if get_variable('applications') == []
@@ -21,4 +22,15 @@ if get_variable('applications').contains('sensor_read')
     c_sources += files([
         'sensor_read.c',
     ])
+endif
+
+if get_variable('applications').contains('xpc_relay')
+    add_project_arguments('-DTASK_EN_XPC_RELAY', language: 'c')
+    peripherals_required += ['uart']
+    devices_required += ['status_leds']
+
+    c_sources += files([
+        'xpc_relay_event_loop.c',
+    ])
+    dependencies += [dependency('tinyxpc', fallback: ['tinyxpc', 'dep_relay'])]
 endif


### PR DESCRIPTION
Demo is available at `demo/xpc_relay_process`.  Instructions in commit message.

The XPC Relay is initialized on UART0 at system startup.
Processes which need to communicate via XPC should first call
`xpc_yield_until_init()` to force them to yield until the relay is
ready.

Other processes writing to UART0 directly should avoid this behavior, as
it will interleave the XPC stream with raw data, which may be
interpreted as XPC messages.  Instead, reserving a "from" channel for
that process' output is advised.