### PR TITLE
Added FTM Driver

### DIFF
--- a/include/drivers/kinetis/ftm.h
+++ b/include/drivers/kinetis/ftm.h
@@ -1,0 +1,2 @@
+#pragma once
+

--- a/include/drivers/kinetis/ftm.h
+++ b/include/drivers/kinetis/ftm.h
@@ -1,2 +1,63 @@
 #pragma once
+#include <MK64F12.h>
+#include <stdint.h>
+#include <stdbool.h>
 
+/*********
+ * TYPES
+ *********/
+typedef struct {
+    uint8_t ftm_num;                /* ftm num to configure */
+    uint32_t *ftm_clock_gate_base;
+    uint32_t ftm_clock_gate_mask;
+    uint32_t freq;                  /* Desired FTM Counter Frequency */
+    uint8_t prescalar;              /* 0-7 Divide by 2^PS */
+    uint8_t clksrc;                 /* 0-3 No CLK, SysCLK, FFCLK, EXCLK */
+    uint16_t cnt_init;              /* uint16 to initialize cnt */
+} ftm_config_t;
+
+typedef struct {
+    uint8_t ftm_num;                /* ftm num where to channel resides */
+    uint8_t channel;                /* ftm channel to configure */
+    uint32_t *port_clock_gate_base;
+    uint32_t port_clock_gate_mask;
+    uint32_t *pcr;                  /* address to the PCR */
+    uint32_t alt;                   /* pin mux alt */
+} ftm_ch_config_t;
+
+/**************
+ * PROTOTYPES
+ **************/
+
+/**
+ * Initializes the FTM peripheral.
+ * @param config A configuration struct for the FTM peripheral.
+ * @param clk_f_hz The frequency of the clock configured for the FTM (before PS).
+ * @return 0
+ */
+int ftm_init(ftm_config_t config, uint32_t clk_f_hz);
+
+/**
+ * Initializes a specific channel for an FTM to edge aligned PWM mode.
+ * @param ch_config A configuration struct for the FTM channel.
+ * @return 0
+ */
+int ftm_ch_epwm_init(ftm_ch_config_t ch_config);
+
+/**
+ * Direct access to the CnV register of a specfic FTM channel.
+ * @param ftm_num The number of the FTM peripheral.
+ * @param ch_num The channel number to be configured.
+ * @param value The value to configure the CnV register.
+ * @return 0
+ */
+int ftm_ch_CnV_set(uint8_t ftm_num, uint8_t ch_num, uint16_t value);
+
+/**
+ * Abstracted access to the CnV register of a specfic FTM channel.
+ * @param ftm_num The number of the FTM peripheral.
+ * @param ch_num The channel number to be configured.
+ * @param duty Duty cycle to set the FTM channel to.
+ * @return 0
+ */
+int ftm_ch_duty_set(uint8_t ftm_num, uint8_t ch_num, uint8_t duty);

--- a/include/environment.h
+++ b/include/environment.h
@@ -1,10 +1,17 @@
 #pragma once
 #include <drivers/kinetis/uart.h>
 #include <drivers/kinetis/i2c.h>
+#include <drivers/kinetis/ftm.h>
 /**
  * The real thing is in src/kernel/environment.c
  */
 extern uart_config uart0_conf;
 extern uart_config uart3_conf;
 extern i2c_config_t i2c0_conf;
+extern ftm_config_t ftm3_conf;
+extern ftm_ch_config_t ftm3_ch5_conf;
+extern ftm_ch_config_t ftm3_ch4_conf;
+extern ftm_config_t ftm0_conf;
+extern ftm_ch_config_t ftm0_ch0_conf;
+extern ftm_ch_config_t ftm0_ch1_conf;
 extern int uart0_fileno;

--- a/src/drivers/kinetis/ftm.c
+++ b/src/drivers/kinetis/ftm.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+#include <drivers/kinetis/ftm.h>
+
+
+typedef struct {
+    uint8_t ftmnum;
+
+} ftm_config_t;
+
+typedef struct {
+    uint8_t channel;
+    uint8_t duty_cycle;
+    uint32_t port_clock_gate_base;
+    uint32_t port_clock_gate_mask;
+    uint32_t pcr;
+
+} ftm_ch_config_t;
+
+
+int ftm_init() {
+    /* enable clock to the FTM module */
+
+    /* disable write protection */
+
+    /* initialize the count to zero */
+
+    /* set the counter initial value to zero */
+
+    /* ftm mod */
+
+
+}

--- a/src/drivers/kinetis/ftm.c
+++ b/src/drivers/kinetis/ftm.c
@@ -1,32 +1,63 @@
+#include <MK64F12.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <drivers/kinetis/ftm.h>
 
 
 typedef struct {
-    uint8_t ftmnum;
-
+    uint8_t ftm_num;
+    uint32_t ftm_clock_gate_base;
+    uint32_t ftm_clock_gate_mask;
+    uint32_t modvalue;
+    int prescalar;                  /* 0-7 Divide by 2^PS */
+    int clksrc;                     /* 0-3 No CLK, SysCLK, FFCLK, EXCLK */
 } ftm_config_t;
 
 typedef struct {
+    uint8_t ftm_num;
     uint8_t channel;
-    uint8_t duty_cycle;
     uint32_t port_clock_gate_base;
     uint32_t port_clock_gate_mask;
     uint32_t pcr;
-
+    uint32_t alt;
 } ftm_ch_config_t;
 
+static FTM_Type *ftm_bases[] = FTM_BASE_PTRS;
 
-int ftm_init() {
+int ftm_init(ftm_config_t *config) {
+    /* get the base pointer */
+    FTM_Type *base = ftm_bases[config.ftm_num];
+
     /* enable clock to the FTM module */
+    *(config.ftm_clk_gate_base) |= config.ftm_clock_gate_mask;
 
     /* disable write protection */
+    base->MODE |= FTM_MODE_WPDIS_MASK;
 
     /* initialize the count to zero */
+    base->CNT = 0;
 
     /* set the counter initial value to zero */
+    base->CNTIN = 0;
 
     /* ftm mod */
+    base->MOD = config.modvalue;
 
+    /* prescalar */
+    base->SC = FTM_SC_PS(config.prescalar) | FTM_SC_CLKS(config.clksrc);
+}
 
+int ch_init(ftm_ch_config_t *ch_config) {
+    /* get the base pointer */
+    FTM_Type *base = ftm_bases[ch_config.ftm_num];
+
+    /* enable the channel port clocks */
+    *(ch_config.port_clock_gate_base) |= ch_config.port_clock_gate_mask;
+
+    /* set the channel port mux */
+    *(ch_config.pcr) = PORT_PCR_MUX(ch_config.alt);
+
+    /* configure for edge aligned, high true pulse PWM */
+    base->CONTROLS[ch_config.channel].CnSC |= FTM_CnSC_MSB_MASK | FTM_CnSC_ELSB_MASK;
+    base->CONTROLS[ch_config.channel].CnSC &= ~FTM_CnSC_ELSA_MASK;
 }

--- a/src/drivers/kinetis/ftm.c
+++ b/src/drivers/kinetis/ftm.c
@@ -3,33 +3,23 @@
 #include <stdbool.h>
 #include <drivers/kinetis/ftm.h>
 
-
-typedef struct {
-    uint8_t ftm_num;
-    uint32_t ftm_clock_gate_base;
-    uint32_t ftm_clock_gate_mask;
-    uint32_t modvalue;
-    int prescalar;                  /* 0-7 Divide by 2^PS */
-    int clksrc;                     /* 0-3 No CLK, SysCLK, FFCLK, EXCLK */
-} ftm_config_t;
-
-typedef struct {
-    uint8_t ftm_num;
-    uint8_t channel;
-    uint32_t port_clock_gate_base;
-    uint32_t port_clock_gate_mask;
-    uint32_t pcr;
-    uint32_t alt;
-} ftm_ch_config_t;
-
+/*************
+ * VARIABLES
+ *************/
 static FTM_Type *ftm_bases[] = FTM_BASE_PTRS;
 
-int ftm_init(ftm_config_t *config) {
+/*************
+ * FUNCTIONS
+ *************/
+int ftm_init(ftm_config_t config, uint32_t clk_f_hz) {
+    uint32_t count_clk;
+    uint16_t modval;
+
     /* get the base pointer */
     FTM_Type *base = ftm_bases[config.ftm_num];
 
     /* enable clock to the FTM module */
-    *(config.ftm_clk_gate_base) |= config.ftm_clock_gate_mask;
+    *(config.ftm_clock_gate_base) |= config.ftm_clock_gate_mask;
 
     /* disable write protection */
     base->MODE |= FTM_MODE_WPDIS_MASK;
@@ -37,27 +27,53 @@ int ftm_init(ftm_config_t *config) {
     /* initialize the count to zero */
     base->CNT = 0;
 
-    /* set the counter initial value to zero */
-    base->CNTIN = 0;
+    /* set the counter initial value */
+    base->CNTIN = config.cnt_init;
 
-    /* ftm mod */
-    base->MOD = config.modvalue;
+    /* set the ftm mod value to ensure the right PWM freq */
+    count_clk = clk_f_hz >> config.prescalar;
+    modval = (count_clk / config.freq) + (config.cnt_init - 1);
+    base->MOD = modval;
 
-    /* prescalar */
+    /* prescalar and clock source */
     base->SC = FTM_SC_PS(config.prescalar) | FTM_SC_CLKS(config.clksrc);
+
+    return 0;
 }
 
-int ch_init(ftm_ch_config_t *ch_config) {
+int ftm_ch_epwm_init(ftm_ch_config_t ch_config) {
     /* get the base pointer */
     FTM_Type *base = ftm_bases[ch_config.ftm_num];
 
     /* enable the channel port clocks */
     *(ch_config.port_clock_gate_base) |= ch_config.port_clock_gate_mask;
 
-    /* set the channel port mux */
-    *(ch_config.pcr) = PORT_PCR_MUX(ch_config.alt);
+    /* set the channel port mux and enable high drive strength */
+    *(ch_config.pcr) = PORT_PCR_MUX(ch_config.alt) | PORT_PCR_DSE_MASK;
 
     /* configure for edge aligned, high true pulse PWM */
     base->CONTROLS[ch_config.channel].CnSC |= FTM_CnSC_MSB_MASK | FTM_CnSC_ELSB_MASK;
     base->CONTROLS[ch_config.channel].CnSC &= ~FTM_CnSC_ELSA_MASK;
+
+    return 0;
+}
+
+int ftm_ch_CnV_set(uint8_t ftm_num, uint8_t ch_num, uint16_t value) {
+    /* get the base pointer */
+    FTM_Type *base = ftm_bases[ftm_num];
+
+    /* set the CnV */
+    base->CONTROLS[ch_num].CnV = value;
+    
+    return 0;
+}
+
+int ftm_ch_duty_set(uint8_t ftm_num, uint8_t ch_num, uint8_t duty) {
+    /* get the base pointer */
+    FTM_Type *base = ftm_bases[ftm_num];
+
+    /* set the CnV */
+    base->CONTROLS[ch_num].CnV = (base->MOD / 100) * duty;
+
+    return 0;
 }

--- a/src/drivers/meson.build
+++ b/src/drivers/meson.build
@@ -24,6 +24,12 @@ if get_variable('target_system', 'MK64F12') == 'MK64F12'
             'kinetis/uart.c',
         ])
     endif
+    if peripherals_required.contains('ftm')
+        add_project_arguments('-DKINETIS_USE_FTM', language: 'c')
+        c_sources += files([
+            'kinetis/ftm.c',
+        ])
+    endif
 endif
 
 if devices_required.contains('altimu')

--- a/src/kernel/environment.c
+++ b/src/kernel/environment.c
@@ -1,6 +1,7 @@
 #include <environment.h>
 #include <drivers/kinetis/uart.h>
 #include <drivers/kinetis/i2c.h>
+#include <drivers/kinetis/ftm.h>
 
 // UART 0 CONFIGURATION (OpenSDA UART <-> USB)
 uart_config uart0_conf = {
@@ -59,5 +60,60 @@ i2c_config_t i2c0_conf = {
     .priority = 0
 };
 
+ftm_config_t ftm3_conf = {
+    .ftm_num = 3u,
+    .ftm_clock_gate_base = &(SIM->SCGC3),
+    .ftm_clock_gate_mask = SIM_SCGC3_FTM3_MASK,
+    .freq = 50u,
+    .prescalar = 5u,
+    .clksrc = 1u,
+    .cnt_init = 0u
+};
+
+ftm_ch_config_t ftm3_ch5_conf = {
+    .ftm_num = 3u,
+    .channel = 5u,
+    .port_clock_gate_base = &(SIM->SCGC5),
+    .port_clock_gate_mask = SIM_SCGC5_PORTC_MASK,
+    .pcr = &(PORTC->PCR[9]),
+    .alt = 3u
+};
+
+ftm_ch_config_t ftm3_ch4_conf = {
+    .ftm_num = 3u,
+    .channel = 4u,
+    .port_clock_gate_base = &(SIM->SCGC5),
+    .port_clock_gate_mask = SIM_SCGC5_PORTC_MASK,
+    .pcr = &(PORTC->PCR[8]),
+    .alt = 3u
+};
+
+ftm_config_t ftm0_conf = {
+    .ftm_num = 0u,
+    .ftm_clock_gate_base = &(SIM->SCGC6),
+    .ftm_clock_gate_mask = SIM_SCGC6_FTM0_MASK,
+    .freq = 400u,
+    .prescalar = 2u,
+    .clksrc = 1u,
+    .cnt_init = 0u
+};
+
+ftm_ch_config_t ftm0_ch0_conf = {
+    .ftm_num = 0u,
+    .channel = 0u,
+    .port_clock_gate_base = &(SIM->SCGC5),
+    .port_clock_gate_mask = SIM_SCGC5_PORTC_MASK,
+    .pcr = &(PORTC->PCR[1]),
+    .alt = 4u
+};
+
+ftm_ch_config_t ftm0_ch1_conf = {
+    .ftm_num = 0u,
+    .channel = 1u,
+    .port_clock_gate_base = &(SIM->SCGC5),
+    .port_clock_gate_mask = SIM_SCGC5_PORTC_MASK,
+    .pcr = &(PORTC->PCR[2]),
+    .alt = 4u
+};
 
 int uart0_fileno;

--- a/src/kernel/kernel_main.c
+++ b/src/kernel/kernel_main.c
@@ -11,6 +11,7 @@
 #include <environment.h>
 #include <drivers/kinetis/i2c.h>
 #include <drivers/kinetis/uart.h>
+#include <drivers/kinetis/ftm.h>
 #include <drivers/devices/altimu.h>
 #include <drivers/devices/status_leds.h>
 
@@ -40,6 +41,11 @@ void kernel_main(const char *cmdline) {
     SIM->SCGC5 |= SIM_SCGC5_PORTB_MASK;
     PORTB->PCR[2] |= PORT_PCR_MUX(2);
     PORTB->PCR[3] |= PORT_PCR_MUX(2);
+#endif
+
+#ifdef KINETIS_USE_FTM
+    ftm_init(ftm3_conf, SystemCoreClock);
+    ftm_init(ftm0_conf, SystemCoreClock);
 #endif
 
     // device initialization here


### PR DESCRIPTION
### Changes for this PR
- kinetis FTM driver (as mentioned)
- configurable initialization structs (auto calculating mod for frequency)
- direct duty cycle CnV set
- abstracted duty cycle set (0-100)
- `environment.c` structs for FTM3 and FTM0 for this project
- one dead K64 because of faulty wiring `F`

Note: `environment.c` currently contains all the configuration structs for devices that we will use in the project. These will be moved out in a separate branch/PR for the servo/esc device drivers.