### PR TITLE
Added a mutual-exclusion lock system call.

### DIFF
--- a/include/kernel/mutex.h
+++ b/include/kernel/mutex.h
@@ -1,0 +1,5 @@
+#pragma once
+
+int kernel_mutex_lock(int *lock);
+
+int kernel_mutex_unlock(int *lock);

--- a/include/multitasking.h
+++ b/include/multitasking.h
@@ -9,3 +9,7 @@
  * run.
  */
 void yield();
+
+int mutex_lock_yield(int *lock);
+int mutex_lock_spin(int *lock);
+int mutex_unlock(int *lock);

--- a/src/kernel/meson.build
+++ b/src/kernel/meson.build
@@ -10,6 +10,8 @@ c_sources += files([
     'service_dispatch.c',
     'schedule.c',
     'private/static_memory.c',
+    'mutex.c',
+    'mutex_lock.c',
 ])
 if get_variable('cpu_arch', 'arm-cortexm4') == 'arm-cortexm4'
     if get_variable('target_system', 'MK64F12') == 'MK64F12'

--- a/src/kernel/mutex.c
+++ b/src/kernel/mutex.c
@@ -1,0 +1,39 @@
+#include <multitasking.h>
+#include <stdint.h>
+#include <stddef.h>
+
+int mutex_lock_yield(int *lock) {
+    int32_t svc_retval = NULL;
+    register int *r0 asm("r0") = lock;
+    register int r1 asm("r1") = 0;
+    register int *r3 asm("r3") = &svc_retval;
+    int r = 0;
+    asm(
+        "svc #3;"
+        : /* no output */
+        : "r" (r0), "r" (r1), "r" (r3)
+    );
+    r = svc_retval;
+    if(r != 0) yield();
+    return r;
+}
+
+int mutex_lock_spin(int *lock) {
+    while(mutex_lock_yield(lock) != 0);
+    return 0;
+}
+
+int mutex_unlock(int *lock) {
+    int32_t svc_retval = NULL;
+    register int *r0 asm("r0") = lock;
+    register int r1 asm("r1") = 1;
+    register int *r3 asm("r3") = &svc_retval;
+    int r = 0;
+    asm(
+        "svc #3;"
+        : /* no output */
+        : "r" (r0), "r" (r1), "r" (r3)
+    );
+    r = svc_retval;
+    return r;
+}

--- a/src/kernel/mutex_lock.c
+++ b/src/kernel/mutex_lock.c
@@ -3,7 +3,7 @@
 
 int kernel_mutex_lock(int *lock) {
     int status = 0;
-    if(*lock == 0) {
+    if(*lock == 0 || *lock == get_syscaller_pid()) {
         *lock = get_syscaller_pid();
     }
     else {

--- a/src/kernel/mutex_lock.c
+++ b/src/kernel/mutex_lock.c
@@ -1,0 +1,24 @@
+#include <kernel/mutex.h>
+#include <kernel/process.h>
+
+int kernel_mutex_lock(int *lock) {
+    int status = 0;
+    if(*lock == 0) {
+        *lock = get_syscaller_pid();
+    }
+    else {
+        status = -1;
+    }
+    return status;
+}
+
+int kernel_mutex_unlock(int *lock) {
+    int status = 0;
+    if(get_syscaller_pid() == *lock) {
+        *lock = 0;
+    }
+    else {
+        status = -1;
+    }
+    return status;
+}

--- a/src/kernel/service_dispatch.c
+++ b/src/kernel/service_dispatch.c
@@ -1,6 +1,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <kernel/stream_io.h>
+#include <kernel/mutex.h>
 
 /**
  * Service call dispatcher
@@ -23,6 +24,15 @@ void svcall_main(uint32_t *args, char svnum) {
             // read
             *(uint32_t*)args[3] = kernel_read(args[0], (char*)args[1], args[2]);
         break;
+
+        case 3:
+            // mutex lock/unlock
+            if(args[1] == 0) {
+                *(uint32_t*)args[3] = kernel_mutex_lock(args[0]);
+            }
+            else {
+                *(uint32_t*)args[3] = kernel_mutex_unlock(args[0]);
+            }
         default:
         break;
     }


### PR DESCRIPTION
This is needed because mutexes need to be atomic, and we have no other
facilities for making that guarantee.

This feature was added to support the xpc relay, and the need to mutex
lock the relay's context.  I was hoping to not have to do this, but
alas, I forgot about the atomicity constraint of mutex locking. How
foolish.